### PR TITLE
Feature/sc linedensity interpolation

### DIFF
--- a/examples/spacecharge/001_prepare_spacecharge_lattice_and_particles.py
+++ b/examples/spacecharge/001_prepare_spacecharge_lattice_and_particles.py
@@ -51,10 +51,10 @@ if particle_type == "ions":
     mass = 193.7e9
     p0c = 1402.406299e9
     charge_state = 82.0
-    neps_x = 1.63e-6 
-    neps_y = 0.86e-6 
+    neps_x = 1.63e-6
+    neps_y = 0.86e-6
     delta_rms = 1.0e-3
-    V_RF_MV = 3 
+    V_RF_MV = 3
     lag_RF_deg = 0.0
     n_SCkicks = 250
     length_fuzzy = 1.5
@@ -182,7 +182,7 @@ with open("line.pkl", "rb") as fid:
 with open("particle_on_CO.pkl", "rb") as fid:
     part_on_CO = pysixtrack.Particles.from_dict(pickle.load(fid))
 
-part = part_on_CO.copy()  
+part = part_on_CO.copy()
 
 # get beta functions from twiss table
 with open("twiss_at_start.pkl", "rb") as fid:

--- a/examples/spacecharge/001_prepare_spacecharge_lattice_and_particles.py
+++ b/examples/spacecharge/001_prepare_spacecharge_lattice_and_particles.py
@@ -94,11 +94,11 @@ mad_sc_names, sc_twdata = bt.get_spacecharge_names_twdata(
 # Check consistency
 if sc_mode == "Bunched":
     sc_elements, sc_names = line.get_elements_of_type(
-        pysixtrack.elements.ScQGaussProfile
+        pysixtrack.elements.SCQGaussProfile
     )
 elif sc_mode == "Coasting":
     sc_elements, sc_names = line.get_elements_of_type(
-        pysixtrack.elements.ScCoasting
+        pysixtrack.elements.SCCoasting
     )
 else:
     raise ValueError("mode not understood")

--- a/examples/spacecharge/001_prepare_spacecharge_lattice_and_particles.py
+++ b/examples/spacecharge/001_prepare_spacecharge_lattice_and_particles.py
@@ -94,11 +94,11 @@ mad_sc_names, sc_twdata = bt.get_spacecharge_names_twdata(
 # Check consistency
 if sc_mode == "Bunched":
     sc_elements, sc_names = line.get_elements_of_type(
-        pysixtrack.elements.SpaceChargeQGaussianProfile
+        pysixtrack.elements.ScQGaussProfile
     )
 elif sc_mode == "Coasting":
     sc_elements, sc_names = line.get_elements_of_type(
-        pysixtrack.elements.SpaceChargeCoasting
+        pysixtrack.elements.ScCoasting
     )
 else:
     raise ValueError("mode not understood")

--- a/pysixtrack/be_beamfields/qgauss.py
+++ b/pysixtrack/be_beamfields/qgauss.py
@@ -44,7 +44,7 @@ class QGauss(object):
     def q(self):
         return self._q
 
-    @property
+    @q.setter
     def q(self, q_value):
         assert q_value < 3
         self._q = q_value

--- a/pysixtrack/be_beamfields/qgauss.py
+++ b/pysixtrack/be_beamfields/qgauss.py
@@ -21,7 +21,7 @@ class QGauss(object):
     @staticmethod
     def sqrt_beta(sigma, mathlib=MathlibDefault):
         assert sigma > 0
-        return 1 / mathlib.sqrt(2 * sigma)
+        return 1 / (mathlib.sqrt(2) * sigma)
 
     @staticmethod
     def exp_q(x, q, mathlib=MathlibDefault, EPS=1e-6):

--- a/pysixtrack/be_beamfields/qgauss.py
+++ b/pysixtrack/be_beamfields/qgauss.py
@@ -1,0 +1,71 @@
+from pysixtrack.mathlibs import MathlibDefault
+
+
+class QGauss(object):
+    @staticmethod
+    def calc_cq(q, mathlib=MathlibDefault, EPS=1e-6):
+        assert q < 3
+        cq = mathlib.sqrt(mathlib.pi)
+        if q >= (1 + EPS):
+            cq *= mathlib.gamma((3 - q) / (2 * q - 2))
+            cq /= mathlib.sqrt((q - 1)) * mathlib.gamma(1 / (q - 1))
+        elif q <= (1 - EPS):
+            cq *= 2 * mathlib.gamma(1 / (1 - q))
+            cq /= (
+                (3 - q)
+                * mathlib.sqrt(1 - q)
+                * mathlib.gamma((3 - q) / (2 - 2 * q))
+            )
+        return cq
+
+    @staticmethod
+    def sqrt_beta(sigma, mathlib=MathlibDefault):
+        assert sigma > 0
+        return 1 / mathlib.sqrt(2 * sigma)
+
+    @staticmethod
+    def exp_q(x, q, mathlib=MathlibDefault, EPS=1e-6):
+        assert q < 3
+        if mathlib.abs(1 - q) > EPS:
+            u_plus = 1 + x * (1 - q)
+            if u_plus < 0:
+                u_plus = 0
+            return mathlib.pow(u_plus, 1 / (1 - q))
+        else:
+            return mathlib.exp(x)
+
+    def __init__(self, q=1.0, mathlib=MathlibDefault, cq_eps=1e-6):
+        assert q < 3
+        self._m = mathlib
+        self._q = q
+        self._cq = QGauss.calc_cq(q, mathlib=mathlib, EPS=cq_eps)
+
+    @property
+    def q(self):
+        return self._q
+
+    @property
+    def q(self, q_value):
+        assert q_value < 3
+        self._q = q_value
+        self._cq = QGauss.calc_cq(self._q, self._m)
+
+    def min_support(self, sqrt_beta):
+        assert self._q < 3
+        assert sqrt_beta > 0
+        if self._q >= 1:
+            return -1e10
+        else:
+            return -1 / self._m.sqrt(sqrt_beta * sqrt_beta * (1 - self._q))
+
+    def max_support(self, sqrt_beta):
+        return -(self.min_support(sqrt_beta))
+
+    def eval(self, x, sqrt_beta, mu=0.0):
+        assert self._m.abs(self._m.cq) > 0
+        assert self._q < 3
+        assert sqrt_beta > 0
+        factor = sqrt_beta / self._cq
+        arg = sqrt_beta * sqrt_beta
+        arg *= (x - mu) * (x - mu)
+        return factor * QGauss.exp_q(-arg, self._q, self._m)

--- a/pysixtrack/be_beamfields/qgauss.py
+++ b/pysixtrack/be_beamfields/qgauss.py
@@ -50,6 +50,10 @@ class QGauss(object):
         self._q = q_value
         self._cq = QGauss.calc_cq(self._q, self._m)
 
+    @property
+    def cq(self):
+        return self._cq
+
     def min_support(self, sqrt_beta):
         assert self._q < 3
         assert sqrt_beta > 0

--- a/pysixtrack/be_beamfields/qgauss.py
+++ b/pysixtrack/be_beamfields/qgauss.py
@@ -62,7 +62,7 @@ class QGauss(object):
         return -(self.min_support(sqrt_beta))
 
     def eval(self, x, sqrt_beta, mu=0.0):
-        assert self._m.abs(self._m.cq) > 0
+        assert self._m.abs(self._cq) > 0
         assert self._q < 3
         assert sqrt_beta > 0
         factor = sqrt_beta / self._cq

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -51,8 +51,7 @@ class SCCoasting(Element):
             p.py += fact_kick * Ey
 
 
-
-class ScQGaussProfile(Element):
+class SCQGaussProfile(Element):
     """Space charge for a bunched beam with generalised
     Gaussian profile.
     """

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -1,5 +1,6 @@
 from pysixtrack.base_classes import Element
 from .gaussian_fields import get_Ex_Ey_Gx_Gy_gauss
+from .qgauss import QGauss
 
 
 class ScCoasting(Element):
@@ -82,15 +83,10 @@ class SpaceChargeQGaussianProfile(Element):
         ("min_sigma_diff", "m", "Threshold to detect round beam", 1e-8),
         ("enabled", "", "Switch to disable space charge effect", True),
         ("q_parameter", "", "q parameter of generalised Gaussian distribution (q=1 for standard Gaussian)", 1.0),
-        ("b_parameter", "", "b parameter of generalised Gaussian distribution (b=1 for standard Gaussian)", 1.0),
     ]
 
     def track(self, p):
         if self.enabled:
-            pi = p._m.pi
-            exp = p._m.exp
-            sqrt = p._m.sqrt
-            bunchlength_rms = self.bunchlength_rms
             length = self.length
             sigma_x = self.sigma_x
             sigma_y = self.sigma_y
@@ -126,15 +122,9 @@ class SpaceChargeQGaussianProfile(Element):
                 * length
             )
 
-            fact_kick *= (
-                self.number_of_particles
-                / (bunchlength_rms * sqrt(2 * pi))
-                * exp(
-                    -0.5
-                    * (sigma / bunchlength_rms)
-                    * (sigma / bunchlength_rms)
-                )
-            )
+            distr = QGauss( self.q, mathlib=p._m )
+            sqrt_beta = QGauss.sqrt_beta( self.bunchlength_rms )
+            fact_kick *= self.number_of_particles * distr( sigma, sqrt_beta )
 
             px += fact_kick * Ex
             py += fact_kick * Ey

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -23,47 +23,33 @@ class SCCoasting(Element):
 
     def track(self, p):
         if self.enabled:
-            length = self.length
-            sigma_x = self.sigma_x
-            sigma_y = self.sigma_y
-
             charge = p.q0 * p.echarge
-            x = p.x - self.x_co
-            px = p.px
-            y = p.y - self.y_co
-            py = p.py
-
-            chi = p.chi
-
             beta = p.beta0 / p.rvv
-            p0c = p.p0c * p.echarge
 
             Ex, Ey = get_Ex_Ey_Gx_Gy_gauss(
-                x,
-                y,
-                sigma_x,
-                sigma_y,
+                p.x - self.x_co,
+                p.y - self.y_co,
+                self.sigma_x,
+                self.sigma_y,
                 min_sigma_diff=self.min_sigma_diff,
                 skip_Gs=True,
                 mathlib=p._m,
             )
 
             fact_kick = (
-                chi
+                p.chi
                 * self.number_of_particles
                 / self.circumference
                 * (charge * p.qratio)
                 * charge
                 * (1 - p.beta0 * beta)
-                / (p0c * beta)
-                * length
+                / (p.p0c * p.echarge * beta)
+                * self.length
             )
 
-            px += fact_kick * Ex
-            py += fact_kick * Ey
+            p.px += fact_kick * Ex
+            p.py += fact_kick * Ey
 
-            p.px = px
-            p.py = py
 
 
 class ScQGaussProfile(Element):

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -128,7 +128,7 @@ class ScQGaussProfile(Element):
                 * length
             )
 
-            distr = QGauss(self.q, mathlib=p._m)
+            distr = QGauss(self.q_parameter, mathlib=p._m)
             sqrt_beta = QGauss.sqrt_beta(self.bunchlength_rms)
             fact_kick *= self.number_of_particles * distr(sigma, sqrt_beta)
 

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -134,12 +134,17 @@ class ScQGaussProfile(Element):
             p.py = py
 
 
-class SpaceChargeInterpolatedProfile(Element):
+class ScInterpolatedProfile(Element):
     """Space charge for a bunched beam with discretised profile."""
 
     _description = [
         ("number_of_particles", "", "Number of particles in the bunch", 0.0),
-        ("line_density_profile", "1/m", "Discretised list of density values with integral normalised to 1", lambda : [1.0, 1.0]),
+        (
+            "line_density_profile",
+            "1/m",
+            "Discretised list of density values with integral normalised to 1",
+            lambda: [1.0, 1.0],
+        ),
         ("dz", "m", "Unit distance in zeta between profile points", 1.0),
         ("z0", "m", "Start zeta position of line density profile", -0.5),
         ("sigma_x", "m", "Horizontal size of the beam (r.m.s.)", 1.0),

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -83,7 +83,12 @@ class ScQGaussProfile(Element):
     _extra = [
         ("min_sigma_diff", "m", "Threshold to detect round beam", 1e-8),
         ("enabled", "", "Switch to disable space charge effect", True),
-        ("q_parameter", "", "q parameter of generalised Gaussian distribution (q=1 for standard Gaussian)", 1.0),
+        (
+            "q_parameter",
+            "",
+            "q parameter of generalised Gaussian distribution (q=1 for standard Gaussian)",
+            1.0,
+        ),
     ]
 
     def track(self, p):
@@ -123,9 +128,9 @@ class ScQGaussProfile(Element):
                 * length
             )
 
-            distr = QGauss( self.q, mathlib=p._m )
-            sqrt_beta = QGauss.sqrt_beta( self.bunchlength_rms )
-            fact_kick *= self.number_of_particles * distr( sigma, sqrt_beta )
+            distr = QGauss(self.q, mathlib=p._m)
+            sqrt_beta = QGauss.sqrt_beta(self.bunchlength_rms)
+            fact_kick *= self.number_of_particles * distr(sigma, sqrt_beta)
 
             px += fact_kick * Ex
             py += fact_kick * Ey

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -104,7 +104,7 @@ class SCQGaussProfile(Element):
             p.py += fact_kick * Ey
 
 
-class ScInterpolatedProfile(Element):
+class SCInterpolatedProfile(Element):
     """Space charge for a bunched beam with discretised profile."""
 
     _description = [

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -4,7 +4,7 @@ from .qgauss import QGauss
 from scipy.interpolate import CubicSpline
 
 
-class ScCoasting(Element):
+class SCCoasting(Element):
     """Space charge for a coasting beam."""
 
     _description = [

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -136,39 +136,27 @@ class SCInterpolatedProfile(Element):
 
     def track(self, p):
         if self.enabled:
-            length = self.length
-            sigma_x = self.sigma_x
-            sigma_y = self.sigma_y
-
             n_prof_points = len(self.line_density_profile)
-
             charge = p.q0 * p.echarge
-            x = p.x - self.x_co
-            px = p.px
-            y = p.y - self.y_co
-            py = p.py
-            chi = p.chi
-
             beta = p.beta0 / p.rvv
-            p0c = p.p0c * p.echarge
 
             Ex, Ey = get_Ex_Ey_Gx_Gy_gauss(
-                x,
-                y,
-                sigma_x,
-                sigma_y,
+                p.x - self.x_co,
+                p.y - self.y_co,
+                self.sigma_x,
+                self.sigma_y,
                 min_sigma_diff=self.min_sigma_diff,
                 skip_Gs=True,
                 mathlib=p._m,
             )
 
             fact_kick = (
-                chi
+                p.chi
                 * (charge * p.qratio)
                 * charge
                 * (1 - p.beta0 * beta)
-                / (p0c * beta)
-                * length
+                / (p.p0c * p.echarge * beta)
+                * self.length
             )
 
             absc_values = p._m.linspace(
@@ -186,8 +174,5 @@ class SCInterpolatedProfile(Element):
                 ld_factor = 1
 
             fact_kick *= self.number_of_particles * ld_factor
-            px += fact_kick * Ex
-            py += fact_kick * Ey
-
-            p.px = px
-            p.py = py
+            p.px += fact_kick * Ex
+            p.py += fact_kick * Ey

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -130,7 +130,7 @@ class ScQGaussProfile(Element):
 
             distr = QGauss(self.q_parameter, mathlib=p._m)
             sqrt_beta = QGauss.sqrt_beta(self.bunchlength_rms)
-            fact_kick *= self.number_of_particles * distr(sigma, sqrt_beta)
+            fact_kick *= self.number_of_particles * distr.eval(sigma, sqrt_beta)
 
             px += fact_kick * Ex
             py += fact_kick * Ey

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -2,7 +2,7 @@ from pysixtrack.base_classes import Element
 from .gaussian_fields import get_Ex_Ey_Gx_Gy_gauss
 
 
-class SpaceChargeCoasting(Element):
+class ScCoasting(Element):
     """Space charge for a coasting beam."""
 
     _description = [

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -65,7 +65,7 @@ class ScCoasting(Element):
             p.py = py
 
 
-class SpaceChargeQGaussianProfile(Element):
+class ScQGaussProfile(Element):
     """Space charge for a bunched beam with generalised
     Gaussian profile.
     """

--- a/pysixtrack/be_beamfields/spacecharge.py
+++ b/pysixtrack/be_beamfields/spacecharge.py
@@ -161,11 +161,6 @@ class SpaceChargeInterpolatedProfile(Element):
 
     def track(self, p):
         if self.enabled:
-            pi = p._m.pi
-            exp = p._m.exp
-            sqrt = p._m.sqrt
-            linspace = p._m.linspace
-
             length = self.length
             sigma_x = self.sigma_x
             sigma_y = self.sigma_y
@@ -177,8 +172,6 @@ class SpaceChargeInterpolatedProfile(Element):
             px = p.px
             y = p.y - self.y_co
             py = p.py
-            sigma = p.sigma
-
             chi = p.chi
 
             beta = p.beta0 / p.rvv

--- a/pysixtrack/be_beamfields/tools.py
+++ b/pysixtrack/be_beamfields/tools.py
@@ -11,10 +11,10 @@ def norm(v):
 
 
 def get_points_twissdata_for_elements(
-        ele_names, mad, seq_name, use_survey=True, use_twiss=True):
+    ele_names, mad, seq_name, use_survey=True, use_twiss=True
+):
 
     mad.use(sequence=seq_name)
-
     mad.twiss()
 
     if use_survey:
@@ -76,8 +76,8 @@ def get_elements(seq, ele_type=None, slot_id=None):
 
 
 def get_points_twissdata_for_element_type(
-        mad, seq_name, ele_type=None, slot_id=None, 
-        use_survey=True, use_twiss=True):
+    mad, seq_name, ele_type=None, slot_id=None, use_survey=True, use_twiss=True
+):
 
     elements, element_names = get_elements(
         seq=mad.sequence[seq_name], ele_type=ele_type, slot_id=slot_id
@@ -115,7 +115,8 @@ def find_alpha_and_phi(dpx, dpy):
 
 
 def get_bb_names_madpoints_sigmas(
-        mad, seq_name, use_survey=True, use_twiss=True):
+    mad, seq_name, use_survey=True, use_twiss=True
+):
     (
         _,
         element_names,
@@ -134,7 +135,8 @@ def get_bb_names_madpoints_sigmas(
 
 
 def shift_strong_beam_based_on_close_ip(
-        points_weak, points_strong, IPs_survey_weak, IPs_survey_strong):
+    points_weak, points_strong, IPs_survey_weak, IPs_survey_strong
+):
 
     for i_bb, _ in enumerate(points_weak):
 
@@ -203,15 +205,16 @@ def find_bb_separations(points_weak, points_strong, names=None):
 
 
 def setup_beam_beam_in_line(
-        line,
-        bb_names,
-        bb_sigmas_strong,
-        bb_points_weak,
-        bb_points_strong,
-        beta_r_strong,
-        bunch_intensity_strong,
-        n_slices_6D,
-        bb_coupling):
+    line,
+    bb_names,
+    bb_sigmas_strong,
+    bb_points_weak,
+    bb_points_strong,
+    beta_r_strong,
+    bunch_intensity_strong,
+    n_slices_6D,
+    bb_coupling,
+):
 
     sep_x, sep_y = find_bb_separations(
         points_weak=bb_points_weak,
@@ -270,7 +273,8 @@ def setup_beam_beam_in_line(
 ##################################
 # space charge related functions #
 ##################################
-sc_mode_to_slotid =  {"Coasting": "1", "Bunched": "2", "Interpolated": "3"}
+sc_mode_to_slotid = {"Coasting": "1", "Bunched": "2", "Interpolated": "3"}
+
 
 def determine_sc_locations(line, n_SCkicks, length_fuzzy):
     s_elements = np.array(line.get_s_elements())
@@ -323,14 +327,15 @@ def get_spacecharge_names_twdata(mad, seq_name, mode):
 
 
 def _setup_spacecharge_in_line(
-        sc_elements,
-        sc_lengths,
-        sc_twdata,
-        betagamma,
-        number_of_particles,
-        delta_rms,
-        neps_x,
-        neps_y):
+    sc_elements,
+    sc_lengths,
+    sc_twdata,
+    betagamma,
+    number_of_particles,
+    delta_rms,
+    neps_x,
+    neps_y,
+):
 
     for ii, ss in enumerate(sc_elements):
         ss.number_of_particles = number_of_particles
@@ -347,24 +352,22 @@ def _setup_spacecharge_in_line(
         ss.y_co = sc_twdata["y"][ii]
         ss.enabled = True
 
+
 def setup_spacecharge_bunched_in_line(
-        sc_elements,
-        sc_lengths,
-        sc_twdata,
-        betagamma,
-        number_of_particles,
-        delta_rms,
-        neps_x,
-        neps_y,
-        bunchlength_rms):
+    sc_elements,
+    sc_lengths,
+    sc_twdata,
+    betagamma,
+    number_of_particles,
+    delta_rms,
+    neps_x,
+    neps_y,
+    bunchlength_rms,
+):
 
     for ii, ss in enumerate(sc_elements):
         ss.bunchlength_rms = bunchlength_rms
     _setup_spacecharge_in_line(
-        sc_elements, sc_lengths, sc_twdata, betagamma, 
-        number_of_particles, delta_rms, neps_x, neps_y)
-
-def setup_spacecharge_coasting_in_line(
         sc_elements,
         sc_lengths,
         sc_twdata,
@@ -373,15 +376,24 @@ def setup_spacecharge_coasting_in_line(
         delta_rms,
         neps_x,
         neps_y,
-        circumference):
+    )
+
+
+def setup_spacecharge_coasting_in_line(
+    sc_elements,
+    sc_lengths,
+    sc_twdata,
+    betagamma,
+    number_of_particles,
+    delta_rms,
+    neps_x,
+    neps_y,
+    circumference,
+):
 
     for ii, ss in enumerate(sc_elements):
         ss.circumference = circumference
     _setup_spacecharge_in_line(
-        sc_elements, sc_lengths, sc_twdata, betagamma, 
-        number_of_particles, delta_rms, neps_x, neps_y)
-
-def setup_spacecharge_interpolated_in_line(
         sc_elements,
         sc_lengths,
         sc_twdata,

--- a/pysixtrack/be_beamfields/tools.py
+++ b/pysixtrack/be_beamfields/tools.py
@@ -402,21 +402,44 @@ def setup_spacecharge_coasting_in_line(
         delta_rms,
         neps_x,
         neps_y,
-        line_density_profile,
-        dz,
-        z0):
+    )
 
+
+def setup_spacecharge_interpolated_in_line(
+    sc_elements,
+    sc_lengths,
+    sc_twdata,
+    betagamma,
+    number_of_particles,
+    delta_rms,
+    neps_x,
+    neps_y,
+    line_density_profile,
+    dz,
+    z0,
+    method=0,
+):
+    assert method == 0 or method == 1
     for ii, ss in enumerate(sc_elements):
         ss.line_density_profile = line_density_profile
         ss.dz = dz
         ss.z0 = z0
+        ss.method = method
     _setup_spacecharge_in_line(
-        sc_elements, sc_lengths, sc_twdata, betagamma,
-        number_of_particles, delta_rms, neps_x, neps_y)
+        sc_elements,
+        sc_lengths,
+        sc_twdata,
+        betagamma,
+        number_of_particles,
+        delta_rms,
+        neps_x,
+        neps_y,
+    )
 
 
 def check_spacecharge_consistency(
-        sc_elements, sc_names, sc_lengths, mad_sc_names):
+    sc_elements, sc_names, sc_lengths, mad_sc_names
+):
     assert len(sc_elements) == len(mad_sc_names)
     assert len(sc_lengths) == len(mad_sc_names)
     for ii, (ss, nn) in enumerate(zip(sc_elements, sc_names)):

--- a/pysixtrack/elements.py
+++ b/pysixtrack/elements.py
@@ -3,9 +3,9 @@ import numpy as np
 from .base_classes import Element
 from .be_beamfields.beambeam import BeamBeam4D
 from .be_beamfields.beambeam import BeamBeam6D
-from .be_beamfields.spacecharge import SpaceChargeCoasting
-from .be_beamfields.spacecharge import SpaceChargeQGaussianProfile
-from .be_beamfields.spacecharge import SpaceChargeInterpolatedProfile
+from .be_beamfields.spacecharge import ScCoasting
+from .be_beamfields.spacecharge import ScQGaussProfile
+from .be_beamfields.spacecharge import ScInterpolatedProfile
 
 _factorial = np.array(
     [
@@ -468,9 +468,9 @@ __all__ = [
     "LimitRect",
     "Multipole",
     "RFMultipole",
+    "ScCoasting",
+    "ScInterpolatedProfile",
+    "ScQGaussProfile",
     "SRotation",
-    "SpaceChargeCoasting",
-    "SpaceChargeInterpolatedProfile",
-    "SpaceChargeQGaussianProfile",
     "XYShift",
 ]

--- a/pysixtrack/elements.py
+++ b/pysixtrack/elements.py
@@ -368,8 +368,7 @@ class LimitRectEllipse(Element):
                 and x <= self.max_x
                 and y >= -self.max_y
                 and y <= self.max_y
-                and x * x / (self.a * self.a) + y * y / (self.b * self.b)
-                <= 1.0
+                and x * x / (self.a * self.a) + y * y / (self.b * self.b) <= 1.0
             )
             if particle.state != 1:
                 return "Particle lost"
@@ -379,10 +378,7 @@ class LimitRectEllipse(Element):
                 & (x <= self.max_x)
                 & (y >= -self.max_y)
                 & (y <= self.max_y)
-                & (
-                    x * x / (self.a * self.a) + y * y / (self.b * self.b)
-                    <= 1.0
-                )
+                & (x * x / (self.a * self.a) + y * y / (self.b * self.b) <= 1.0)
             )
             particle.remove_lost_particles()
             if len(particle.state) == 0:

--- a/pysixtrack/elements.py
+++ b/pysixtrack/elements.py
@@ -5,6 +5,7 @@ from .be_beamfields.beambeam import BeamBeam4D
 from .be_beamfields.beambeam import BeamBeam6D
 from .be_beamfields.spacecharge import SpaceChargeCoasting
 from .be_beamfields.spacecharge import SpaceChargeQGaussianProfile
+from .be_beamfields.spacecharge import SpaceChargeInterpolatedProfile
 
 _factorial = np.array(
     [
@@ -468,7 +469,8 @@ __all__ = [
     "Multipole",
     "RFMultipole",
     "SRotation",
-    "SpaceChargeQGaussianProfile",
     "SpaceChargeCoasting",
+    "SpaceChargeInterpolatedProfile",
+    "SpaceChargeQGaussianProfile",
     "XYShift",
 ]

--- a/pysixtrack/elements.py
+++ b/pysixtrack/elements.py
@@ -3,9 +3,9 @@ import numpy as np
 from .base_classes import Element
 from .be_beamfields.beambeam import BeamBeam4D
 from .be_beamfields.beambeam import BeamBeam6D
-from .be_beamfields.spacecharge import ScCoasting
-from .be_beamfields.spacecharge import ScQGaussProfile
-from .be_beamfields.spacecharge import ScInterpolatedProfile
+from .be_beamfields.spacecharge import SCCoasting
+from .be_beamfields.spacecharge import SCQGaussProfile
+from .be_beamfields.spacecharge import SCInterpolatedProfile
 
 _factorial = np.array(
     [
@@ -464,9 +464,9 @@ __all__ = [
     "LimitRect",
     "Multipole",
     "RFMultipole",
-    "ScCoasting",
-    "ScInterpolatedProfile",
-    "ScQGaussProfile",
+    "SCCoasting",
+    "SCInterpolatedProfile",
+    "SCQGaussProfile",
     "SRotation",
     "XYShift",
 ]

--- a/pysixtrack/loader_mad.py
+++ b/pysixtrack/loader_mad.py
@@ -158,11 +158,11 @@ def iter_from_madx_sequence(
                 )
         elif mad_etype == "placeholder":
             if ee.slot_id == 1:
-                newele = classes.ScCoasting()
+                newele = classes.SCCoasting()
             elif ee.slot_id == 2:
-                newele = classes.ScQGaussProfile()
+                newele = classes.SCQGaussProfile()
             elif ee.slot_id == 3:
-                newele = classes.ScInterpolatedProfile()
+                newele = classes.SCInterpolatedProfile()
             else:
                 newele = myDrift(length=ee.l)
                 old_pp += ee.l

--- a/pysixtrack/loader_mad.py
+++ b/pysixtrack/loader_mad.py
@@ -49,7 +49,7 @@ def iter_from_madx_sequence(
             "drift",
         ]:
             newele = myDrift(length=ee.l)
-            old_pp+=ee.l
+            old_pp += ee.l
 
         elif mad_etype in ignored_madtypes:
             pass

--- a/pysixtrack/loader_mad.py
+++ b/pysixtrack/loader_mad.py
@@ -158,11 +158,11 @@ def iter_from_madx_sequence(
                 )
         elif mad_etype == "placeholder":
             if ee.slot_id == 1:
-                newele = classes.SpaceChargeCoasting()
+                newele = classes.ScCoasting()
             elif ee.slot_id == 2:
-                newele = classes.SpaceChargeQGaussianProfile()
+                newele = classes.ScQGaussProfile()
             elif ee.slot_id == 3:
-                newele = classes.SpaceChargeInterpolatedProfile()
+                newele = classes.ScInterpolatedProfile()
             else:
                 newele = myDrift(length=ee.l)
                 old_pp += ee.l

--- a/pysixtrack/mathlibs.py
+++ b/pysixtrack/mathlibs.py
@@ -1,11 +1,18 @@
 from scipy.special import wofz
+from scipy.special import gamma as tgamma
 
 
 class MathlibDefault(object):
 
     from numpy import sqrt, exp, sin, cos, abs, pi, tan, interp, linspace
+    from numpy import power as pow
 
     @classmethod
     def wfun(cls, z_re, z_im):
         w = wofz(z_re + 1j * z_im)
         return w.real, w.imag
+
+    @classmethod
+    def gamma(cls, arg):
+        assert arg > 0.0
+        return tgamma(arg)

--- a/tests/test_beamfields.py
+++ b/tests/test_beamfields.py
@@ -1,7 +1,6 @@
 import numpy as np
-
-from pysixtrack.mathlibs import MathlibDefault
 import pysixtrack
+from pysixtrack.mathlibs import MathlibDefault
 from pysixtrack.be_beamfields.gaussian_fields import (
     _get_transv_field_gauss_ellip,
 )
@@ -97,3 +96,7 @@ def test_get_transv_field_gauss_ellip():
         )
     except ZeroDivisionError:
         pass  # test passed
+
+
+if __name__ == "__main__":
+    test_track_spacecharge()

--- a/tests/test_beamfields.py
+++ b/tests/test_beamfields.py
@@ -12,7 +12,7 @@ def test_track_spacecharge():
     y_co = -0.5
     sigma_x = 0.5
     sigma_y = 0.1
-    el1 = pysixtrack.elements.ScQGaussProfile(
+    el1 = pysixtrack.elements.SCQGaussProfile(
         number_of_particles=1e11,
         bunchlength_rms=0.22,
         sigma_x=sigma_x,
@@ -21,7 +21,7 @@ def test_track_spacecharge():
         x_co=x_co,
         y_co=y_co,
     )
-    el2 = pysixtrack.elements.ScCoasting(
+    el2 = pysixtrack.elements.SCCoasting(
         number_of_particles=el1.number_of_particles,
         circumference=el1.bunchlength_rms * np.sqrt(2 * np.pi),
         sigma_x=el1.sigma_x,

--- a/tests/test_beamfields.py
+++ b/tests/test_beamfields.py
@@ -12,7 +12,7 @@ def test_track_spacecharge():
     y_co = -0.5
     sigma_x = 0.5
     sigma_y = 0.1
-    el1 = pysixtrack.elements.SpaceChargeQGaussianProfile(
+    el1 = pysixtrack.elements.ScQGaussProfile(
         number_of_particles=1e11,
         bunchlength_rms=0.22,
         sigma_x=sigma_x,
@@ -21,7 +21,7 @@ def test_track_spacecharge():
         x_co=x_co,
         y_co=y_co,
     )
-    el2 = pysixtrack.elements.SpaceChargeCoasting(
+    el2 = pysixtrack.elements.ScCoasting(
         number_of_particles=el1.number_of_particles,
         circumference=el1.bunchlength_rms * np.sqrt(2 * np.pi),
         sigma_x=el1.sigma_x,

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -122,7 +122,8 @@ def test_error_import():
 
     madx = Madx()
 
-    madx.input('''
+    madx.input(
+        """
         MQ1: Quadrupole, K1:=KQ1, L=1.0, apertype=CIRCLE, aperture={0.04};
         MQ2: Quadrupole, K1:=KQ2, L=1.0, apertype=CIRCLE, aperture={0.04};
         MQ3: Quadrupole, K1:=0.0, L=1.0, apertype=CIRCLE, aperture={0.04};
@@ -158,70 +159,76 @@ def test_error_import():
         ealign, dx = 0.00, dy = 0.00, arex = 0.00, arey = 0.00, dpsi = 0.00;
         efcomp, DKN = {0.0, 0.0, 0.001, 0.002}, DKS = {0.0, 0.0, 0.003, 0.004};
         select, flag = error, full;
-    ''')
+    """
+    )
     seq = madx.sequence.testseq
     # store already applied errors:
-    madx.command.esave(file='lattice_errors.err')
-    madx.command.readtable(file='lattice_errors.err', table="errors")
-    os.remove('lattice_errors.err')
+    madx.command.esave(file="lattice_errors.err")
+    madx.command.readtable(file="lattice_errors.err", table="errors")
+    os.remove("lattice_errors.err")
     errors = madx.table.errors
 
-    pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
+    pysixtrack_line = pysixtrack.Line.from_madx_sequence(
+        seq, install_apertures=True
+    )
     pysixtrack_line.apply_madx_errors(errors)
-    madx.input('stop;')
+    madx.input("stop;")
 
     expected_element_num = (
-            2           # start and end marker
-            + 6          # drifts (including drift between MQ1 slices)
-            + 3 + 2        # quadrupoles + MQ1 slices
-            + 3 + 2        # corresponding aperture elements
-            + 2*(3+1)    # dx/y in/out for MQ1 slices and MQ2
-            + 2          # tilt in/out for MQ2
-            + 2*3        # arex/y in/out for MQ1 slices
-            )
+        2  # start and end marker
+        + 6  # drifts (including drift between MQ1 slices)
+        + 3
+        + 2  # quadrupoles + MQ1 slices
+        + 3
+        + 2  # corresponding aperture elements
+        + 2 * (3 + 1)  # dx/y in/out for MQ1 slices and MQ2
+        + 2  # tilt in/out for MQ2
+        + 2 * 3  # arex/y in/out for MQ1 slices
+    )
     assert len(pysixtrack_line) == expected_element_num
 
     expected_element_order = [
-            pysixtrack.elements.Drift,          # start marker
-            pysixtrack.elements.Drift,
-            pysixtrack.elements.XYShift,        # dx/y in of MQ1 1st slice
-            pysixtrack.elements.Multipole,      # MQ1 1st slice
-            pysixtrack.elements.XYShift,        # arex/y in for MQ1 1st slice
-            pysixtrack.elements.LimitEllipse,   # MQ1 1st slice aperture
-            pysixtrack.elements.XYShift,        # arex/y out for MQ1 1st slice
-            pysixtrack.elements.XYShift,        # dx/y out for MQ1 1st slice
-            pysixtrack.elements.Drift,
-            pysixtrack.elements.XYShift,        # dx/y in for MQ1 marker
-            pysixtrack.elements.Drift,          # MQ1 marker
-            pysixtrack.elements.XYShift,        # arex/y in for MQ1 marker
-            pysixtrack.elements.LimitEllipse,   # MQ1 marker aperture
-            pysixtrack.elements.XYShift,        # arex/y out for MQ1 marker
-            pysixtrack.elements.XYShift,        # dx/y out for MQ1 marker
-            pysixtrack.elements.Drift,
-            pysixtrack.elements.XYShift,        # dx/y in for MQ1 2nd slice
-            pysixtrack.elements.Multipole,      # MQ1 2nd slice
-            pysixtrack.elements.XYShift,        # arex/y in for MQ1 2nd slice
-            pysixtrack.elements.LimitEllipse,   # MQ1 2nd slice aperture
-            pysixtrack.elements.XYShift,        # arex/y out for MQ1 2nd slice
-            pysixtrack.elements.XYShift,        # dx/y out for MQ1 2nd slice
-            pysixtrack.elements.Drift,
-            pysixtrack.elements.XYShift,        # dx/y in for MQ2
-            pysixtrack.elements.SRotation,      # tilt in for MQ2
-            pysixtrack.elements.Multipole,      # MQ2
-            pysixtrack.elements.LimitEllipse,   # MQ2 aperture
-            pysixtrack.elements.SRotation,      # tilt out for MQ2
-            pysixtrack.elements.XYShift,        # dx/y out for MQ2
-            pysixtrack.elements.Drift,
-            pysixtrack.elements.Multipole,      # MQ3
-            pysixtrack.elements.LimitEllipse,   # MQ3 aperture
-            pysixtrack.elements.Drift,
-            pysixtrack.elements.Drift           # end marker
-            ]
-    for element, expected_element in zip(pysixtrack_line.elements,
-                                         expected_element_order):
+        pysixtrack.elements.Drift,  # start marker
+        pysixtrack.elements.Drift,
+        pysixtrack.elements.XYShift,  # dx/y in of MQ1 1st slice
+        pysixtrack.elements.Multipole,  # MQ1 1st slice
+        pysixtrack.elements.XYShift,  # arex/y in for MQ1 1st slice
+        pysixtrack.elements.LimitEllipse,  # MQ1 1st slice aperture
+        pysixtrack.elements.XYShift,  # arex/y out for MQ1 1st slice
+        pysixtrack.elements.XYShift,  # dx/y out for MQ1 1st slice
+        pysixtrack.elements.Drift,
+        pysixtrack.elements.XYShift,  # dx/y in for MQ1 marker
+        pysixtrack.elements.Drift,  # MQ1 marker
+        pysixtrack.elements.XYShift,  # arex/y in for MQ1 marker
+        pysixtrack.elements.LimitEllipse,  # MQ1 marker aperture
+        pysixtrack.elements.XYShift,  # arex/y out for MQ1 marker
+        pysixtrack.elements.XYShift,  # dx/y out for MQ1 marker
+        pysixtrack.elements.Drift,
+        pysixtrack.elements.XYShift,  # dx/y in for MQ1 2nd slice
+        pysixtrack.elements.Multipole,  # MQ1 2nd slice
+        pysixtrack.elements.XYShift,  # arex/y in for MQ1 2nd slice
+        pysixtrack.elements.LimitEllipse,  # MQ1 2nd slice aperture
+        pysixtrack.elements.XYShift,  # arex/y out for MQ1 2nd slice
+        pysixtrack.elements.XYShift,  # dx/y out for MQ1 2nd slice
+        pysixtrack.elements.Drift,
+        pysixtrack.elements.XYShift,  # dx/y in for MQ2
+        pysixtrack.elements.SRotation,  # tilt in for MQ2
+        pysixtrack.elements.Multipole,  # MQ2
+        pysixtrack.elements.LimitEllipse,  # MQ2 aperture
+        pysixtrack.elements.SRotation,  # tilt out for MQ2
+        pysixtrack.elements.XYShift,  # dx/y out for MQ2
+        pysixtrack.elements.Drift,
+        pysixtrack.elements.Multipole,  # MQ3
+        pysixtrack.elements.LimitEllipse,  # MQ3 aperture
+        pysixtrack.elements.Drift,
+        pysixtrack.elements.Drift,  # end marker
+    ]
+    for element, expected_element in zip(
+        pysixtrack_line.elements, expected_element_order
+    ):
         assert isinstance(element, expected_element)
 
-    idx_MQ3 = pysixtrack_line.element_names.index('mq3')
+    idx_MQ3 = pysixtrack_line.element_names.index("mq3")
     MQ3 = pysixtrack_line.elements[idx_MQ3]
     assert abs(MQ3.knl[2] - 0.001) < 1e-14
     assert abs(MQ3.knl[3] - 0.002) < 1e-14
@@ -240,7 +247,8 @@ def test_neutral_errors():
 
     madx = Madx()
 
-    madx.input('''
+    madx.input(
+        """
         T1: Collimator, L=1.0, apertype=CIRCLE, aperture={0.5};
         T2: Collimator, L=1.0, apertype=CIRCLE, aperture={0.5};
         T3: Collimator, L=1.0, apertype=CIRCLE, aperture={0.5};
@@ -275,17 +283,20 @@ def test_neutral_errors():
         select, flag = error, pattern = "T3";
         ealign, dx = 0.02, dy = 0.01, arex = 0.03, arey = 0.02, dpsi = 0.1;
         select, flag = error, full;
-    ''')
+    """
+    )
     seq = madx.sequence.testseq
     # store already applied errors:
-    madx.command.esave(file='lattice_errors.err')
-    madx.command.readtable(file='lattice_errors.err', table="errors")
-    os.remove('lattice_errors.err')
+    madx.command.esave(file="lattice_errors.err")
+    madx.command.readtable(file="lattice_errors.err", table="errors")
+    os.remove("lattice_errors.err")
     errors = madx.table.errors
 
-    pysixtrack_line = pysixtrack.Line.from_madx_sequence(seq, install_apertures=True)
+    pysixtrack_line = pysixtrack.Line.from_madx_sequence(
+        seq, install_apertures=True
+    )
     pysixtrack_line.apply_madx_errors(errors)
-    madx.input('stop;')
+    madx.input("stop;")
 
     initial_x = 0.025
     initial_y = -0.015
@@ -297,5 +308,5 @@ def test_neutral_errors():
 
     pysixtrack_line.track(particle)
 
-    assert abs(particle.x-initial_x) < 1e-14
-    assert abs(particle.y-initial_y) < 1e-14
+    assert abs(particle.x - initial_x) < 1e-14
+    assert abs(particle.y - initial_y) < 1e-14

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -71,11 +71,11 @@ def test_madx_import():
         # Check consistency
         if sc_mode == "Bunched":
             sc_elements, sc_names = line.get_elements_of_type(
-                pysixtrack.elements.SpaceChargeQGaussianProfile
+                pysixtrack.elements.ScQGaussProfile
             )
         elif sc_mode == "Coasting":
             sc_elements, sc_names = line.get_elements_of_type(
-                pysixtrack.elements.SpaceChargeCoasting
+                pysixtrack.elements.ScCoasting
             )
         else:
             raise ValueError("mode not understood")

--- a/tests/test_madx_import.py
+++ b/tests/test_madx_import.py
@@ -71,11 +71,11 @@ def test_madx_import():
         # Check consistency
         if sc_mode == "Bunched":
             sc_elements, sc_names = line.get_elements_of_type(
-                pysixtrack.elements.ScQGaussProfile
+                pysixtrack.elements.SCQGaussProfile
             )
         elif sc_mode == "Coasting":
             sc_elements, sc_names = line.get_elements_of_type(
-                pysixtrack.elements.ScCoasting
+                pysixtrack.elements.SCCoasting
             )
         else:
             raise ValueError("mode not understood")

--- a/tests/test_qgauss.py
+++ b/tests/test_qgauss.py
@@ -1,0 +1,33 @@
+import numpy as np
+from pysixtrack.mathlibs import MathlibDefault
+from pysixtrack.be_beamfields.qgauss import QGauss
+
+
+def test_qgauss_gauss_compare():
+    def gauss_distr(x, sigma, mu=0.0):
+        sigma_squ = sigma * sigma
+        arg = (x - mu) / sigma
+        return np.exp(-arg * arg / 2.0) / np.sqrt(2 * np.pi * sigma_squ)
+
+    q = 1.0
+    sigma1 = 1.0
+    abscissa = np.linspace(-4 * sigma1, 4 * sigma1, 101)
+    cmp_gauss1 = gauss_distr(abscissa, sigma1)
+
+    EPS = float(1e-16)
+    distr = QGauss(q)
+    assert distr.q == 1.0
+    assert np.allclose(distr.cq, np.sqrt(np.pi), EPS, EPS)
+
+    gauss1 = distr.eval(abscissa, QGauss.sqrt_beta(sigma1))
+    assert np.allclose(cmp_gauss1, gauss1, EPS, EPS)
+
+    sigma2 = 2.37
+    abscissa = np.linspace(-4 * sigma2, 4 * sigma2, 101)
+    cmp_gauss2 = gauss_distr(abscissa, sigma2)
+    gauss2 = distr.eval(abscissa, QGauss.sqrt_beta(sigma2))
+    assert np.allclose(cmp_gauss2, gauss2, EPS, EPS)
+
+
+if __name__ == "__main__":
+    test_qgauss_gauss_compare()

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -19,8 +19,8 @@ element_list = [
     pysixtrack.elements.LimitRectEllipse,
     pysixtrack.elements.BeamBeam4D,
     pysixtrack.elements.BeamBeam6D,
-    pysixtrack.elements.ScCoasting,
-    pysixtrack.elements.ScQGaussProfile,
+    pysixtrack.elements.SCCoasting,
+    pysixtrack.elements.SCQGaussProfile,
 ]
 
 

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -19,8 +19,8 @@ element_list = [
     pysixtrack.elements.LimitRectEllipse,
     pysixtrack.elements.BeamBeam4D,
     pysixtrack.elements.BeamBeam6D,
-    pysixtrack.elements.SpaceChargeCoasting,
-    pysixtrack.elements.SpaceChargeQGaussianProfile,
+    pysixtrack.elements.ScCoasting,
+    pysixtrack.elements.ScQGaussProfile,
 ]
 
 


### PR DESCRIPTION
Proposed updates to SixTrack/pysixtrack#50 to bring it in line with SixTrack/sixtracklib#132. 
- Shorten the names of the space charge elements
- introduce interpolation method attribute to * ScInterpolatedProfile*
- use linear and cubic spline interpolation in the tracking function of `ScInterpolatedProfile` 
- add a `QGauss` helper class similar to the implementation used by SixTrackLib
- remove b-parameter from `ScQGaussProfile` as the related cq parameter can be calculated from the q-parameter
- use the `QGauss` helper during tracking over `ScQGaussProfile`
- add method parameter to the `setup_spacecharge_interpolated_in_line` method and default to linear interpolation
- cosmetic changes and linter to make the sources conform with PEP8
- update examples, tests and MAD-X loader to make use of the new APIs
- added missing methods (`gamma`, `pow`) to the default `MathlibDefault` implementation

Remaining open points not included in this PR:
- in some places (i.e. see `pysixtrack/loader_mad.py` for example) , we are using numpy direct and not `MathlibDefault` or the particle mathlib implementation -> should we change this?
- I've not run tests involving MAD-X as I currently do not have a working implementation running locally -> I try to rectify this asap

Could you please review whether you agree with these changes? If yes, I would perform the final round of changes in SixTrackLib to bring it in line with these pysixtrack changes
